### PR TITLE
Remove unused System.Linq.Async package

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.Tests/Pure.RelationalSchema.Storage.Tests.csproj
+++ b/src/Tests/Pure.RelationalSchema.Storage.Tests/Pure.RelationalSchema.Storage.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Pure.RelationalSchema.HashCodes" Version="3.3.0" />
     <PackageReference Include="Pure.RelationalSchema.Random" Version="1.1.0" />
     <PackageReference Include="Pure.RelationalSchema.Storage.HashCodes" Version="0.1.0-preview.2.2.0" />
-    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
Audit of all NuGet references across the solution per #43:
- No duplicate packages found.
- No outdated packages found (all resolvable public packages are at their latest versions).
- One unused package identified: `System.Linq.Async` in the test project - none of its extension methods are referenced anywhere in the code.

Removes `System.Linq.Async` from the test project.

Closes #43